### PR TITLE
default dns.config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .vscode
 /target
-dns.config.yaml
 .idea

--- a/dns.config.yaml
+++ b/dns.config.yaml
@@ -2,5 +2,5 @@ listening-port: 53
 remote-lookup-port: 42069
 thread-count: 1
 use-udp: true
-use-tcp: true
+use-tcp: false
 database-file: "~/.config/simpledns/simpledns.sqlite.db"

--- a/dns.config.yaml
+++ b/dns.config.yaml
@@ -1,0 +1,6 @@
+listening-port: 53
+remote-lookup-port: 42069
+thread-count: 1
+use-udp: true
+use-tcp: true
+database-file: "~/.config/simpledns/simpledns.sqlite.db"

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,15 +32,15 @@ struct Args {
 #[derive(Debug, Subcommand)]
 enum Commands {
   Start {
-    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
     config: String,
   },
   Init {
-    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
     config: String,
   },
   Add {
-    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
     config: String,
     #[arg(short, long, action)]
     interactive: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,15 +32,15 @@ struct Args {
 #[derive(Debug, Subcommand)]
 enum Commands {
   Start {
-    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
     config: String,
   },
   Init {
-    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
     config: String,
   },
   Add {
-    #[arg(short, long, value_parser, default_value = "~/.config/simpledns/dns.config.yaml")]
+    #[arg(short, long, value_parser, default_value = "./dns.config.yaml")]
     config: String,
     #[arg(short, long, action)]
     interactive: bool,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -42,7 +42,7 @@ impl DnsSettings {
         };
         let use_tcp = match config_settings["use-tcp"].as_bool() {
           Some(x) => x,
-          None => true,
+          None => false, // TODO should be set true when this functionality is working properly
         };
 
         let database_file = shellexpand::full(


### PR DESCRIPTION
practicing pull requests, feel free to reject this if it's not what you want ty

current repo fails with 'cargo run init' because there is no default configuration file. as a quick fix, i threw this together from the defaults in settings.rs. i then changed the default config file location to the current directory to make code more compatible across platforms. i do see that you had explicitly added this file to .gitignore, a better solution would probably be to generate a new empty configfile if file access failed and i might do that next if that's alright